### PR TITLE
Add a slug field, used as a friendly id for boards

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.1)

--- a/app/controllers/admin/boards_controller.rb
+++ b/app/controllers/admin/boards_controller.rb
@@ -9,6 +9,8 @@ module Admin
       )
     end
 
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    def find_resource(param)
+      Board.find_by!(slug: param)
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,6 @@ class ApplicationController < ActionController::Base
     end
 
     def load_boards
-      @boards = Board.select(:id, :name).order(order: :asc)
+      @boards = Board.select(:id, :name, :slug).order(order: :asc)
     end
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,5 +1,5 @@
 class BoardsController < ApplicationController
   def show
-    @board = Board.find(params[:id])
+    @board = Board.find_by(slug: params[:id])
   end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -4,6 +4,7 @@ class Board < ApplicationRecord
   after_initialize :set_order_to_last
 
   validates :name, presence: true, uniqueness: true
+  validates :slug, presence: true, uniqueness: true
   validates :description, length: { in: 0..1024 }, allow_nil: true
 
   def set_order_to_last
@@ -12,5 +13,16 @@ class Board < ApplicationRecord
     
     order_last = Board.maximum(:order) || 0
     self.order = order_last + 1
+  end
+
+  def name=(value)
+    if self.slug.blank?
+      self.slug = value.to_s.parameterize
+    end
+    super(value)
+  end
+
+  def to_param
+    self.slug
   end
 end

--- a/db/migrate/20210207214535_add_slug_to_boards.rb
+++ b/db/migrate/20210207214535_add_slug_to_boards.rb
@@ -1,0 +1,17 @@
+class AddSlugToBoards < ActiveRecord::Migration[6.0]
+  def up
+    add_column :boards, :slug, :string, null: true
+    add_index :boards, :slug, unique: true
+
+    Board.find_each do |board|
+      slug = board.name.parameterize
+      board.update!(slug: slug)
+    end
+
+    change_column_null :boards, :slug, false
+  end
+
+  def down
+    remove_column :boards, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_215831) do
+ActiveRecord::Schema.define(version: 2021_02_07_214535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,9 @@ ActiveRecord::Schema.define(version: 2021_01_26_215831) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "order", null: false
+    t.string "slug", null: false
     t.index ["name"], name: "index_boards_on_name", unique: true
+    t.index ["slug"], name: "index_boards_on_slug", unique: true
   end
 
   create_table "comments", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,8 @@ admin = User.create(
 )
 
 # Create some boards
-feature_board = Board.create(name: 'Feature Requests', description: 'Post here your feature requests.')
-bug_board = Board.create(name: 'Bug Reports', description: 'Post here your bug reports.')
+feature_board = Board.create(name: 'Feature Requests', description: 'Post here your feature requests.', slug: 'feature-requests')
+bug_board = Board.create(name: 'Bug Reports', description: 'Post here your bug reports.', slug: 'bug-reports')
 
 # Create some post statuses
 planned_post_status = PostStatus.create(name: 'Planned', color: '#0096ff', order: 1, show_in_roadmap: true)

--- a/spec/factories/boards.rb
+++ b/spec/factories/boards.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :board do
     sequence(:name) { |n| "Board#{n}" }
+    sequence(:slug) { |n| "board#{n}" }
     description { 'My fantastic board' }
     order { 1 }
   end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -38,4 +38,22 @@ RSpec.describe Board, type: :model do
     expect(board1.order).to eq(order)
     expect(board2.order).to eq(order + 1)
   end
+
+  describe '.to_param' do
+    it 'uses the name as param' do
+      board = FactoryBot.build(:board, name: 'Random Board', slug: nil)
+
+      board.update(name: "Example")
+      
+      expect(board.to_param).to eq('example')
+    end
+
+    it 'transforms name using parameterize' do
+      board = FactoryBot.build(:board, name: 'Random Board', slug: nil)
+      
+      board.update(name: "My Funky Name")
+
+      expect(board.to_param).to eq('my-funky-name')
+    end
+  end
 end

--- a/spec/requests/admin_panel_boards_spec.rb
+++ b/spec/requests/admin_panel_boards_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe 'requests to boards in the admin panel', :admin_panel, type: :req
       expect(response).to redirect_to(new_user_session_path)
     end
     it 'redirects create action' do
-      post admin_boards_path, params: { board: { name: board.name + 'a' } }
+      post admin_boards_path, params: { board: { name: 'fakename' } }
       expect(response).to redirect_to(new_user_session_path)
     end
     it 'redirects update action' do
-      patch admin_board_path(board), params: { board: { name: board.name + 'a' } }
+      patch admin_board_path(board), params: { board: { name: 'newname' } }
       expect(response).to redirect_to(new_user_session_path)
     end
     it 'redirects destroy action' do
@@ -61,11 +61,11 @@ RSpec.describe 'requests to boards in the admin panel', :admin_panel, type: :req
       expect(response).to redirect_to(root_path)
     end
     it 'redirects create action' do
-      post admin_boards_path, params: { board: { name: board.name + 'a' } }
+      post admin_boards_path, params: { board: { name: 'fakename' } }
       expect(response).to redirect_to(root_path)
     end
     it 'redirects update action' do
-      patch admin_board_path(board), params: { board: { name: board.name + 'a' } }
+      patch admin_board_path(board), params: { board: { name: 'newname' } }
       expect(response).to redirect_to(root_path)
     end
     it 'redirects destroy action' do
@@ -97,11 +97,15 @@ RSpec.describe 'requests to boards in the admin panel', :admin_panel, type: :req
       expect(response).to have_http_status(:success)
     end
     it 'fulfills create action' do
-      post admin_boards_path, params: { board: { name: board.name + 'a' } }
-      expect(response).to redirect_to(admin_board_path(board.id + 1))
+      post admin_boards_path, params: { board: { name: 'fakename'} }
+
+      new_board = Board.last
+      expect(new_board.name).to eq('fakename')
+      expect(response).to redirect_to(admin_board_path(new_board))
     end
     it 'fulfills update action' do
-      patch admin_board_path(board), params: { board: { name: board.name + 'a' } }
+      patch admin_board_path(board), params: { board: { name: 'newname' } }
+      expect(board.reload.name).to eq('newname')
       expect(response).to redirect_to(admin_board_path(board))
     end
     it 'fulfills destroy action' do
@@ -133,11 +137,14 @@ RSpec.describe 'requests to boards in the admin panel', :admin_panel, type: :req
       expect(response).to have_http_status(:success)
     end
     it 'fulfills create action' do
-      post admin_boards_path, params: { board: { name: board.name + 'a' } }
-      expect(response).to redirect_to(admin_board_path(board.id + 1))
+      post admin_boards_path, params: { board: { name: 'fakename' } }
+      new_board = Board.last
+      expect(new_board.name).to eq('fakename')
+      expect(response).to redirect_to(admin_board_path(new_board))
     end
     it 'fulfills update action' do
-      patch admin_board_path(board), params: { board: { name: board.name + 'a' } }
+      patch admin_board_path(board), params: { board: { name: 'newname' } }
+      expect(board.reload.name).to eq('newname')
       expect(response).to redirect_to(admin_board_path(board))
     end
     it 'fulfills destroy action' do


### PR DESCRIPTION
Refers and closes #40

:warning: For an existing app, it'd be necessary to adapt the migration,
because `null: false` constraint would be broken for slugs.

It might be just easier to use a gem such a [friendly+id](https://github.com/norman/friendly_id) : more features are available through it but are they needed ? I didn't know but completely open to discuss this topic :)) 