### PR TITLE
Collapse board list into dropdown if > 5 boards

### DIFF
--- a/app/views/layouts/_boards_menu_section.html.erb
+++ b/app/views/layouts/_boards_menu_section.html.erb
@@ -1,5 +1,20 @@
-<% boards.each do |board| %>
-  <li class="nav-item<%= board.id == @board.id ? ' active' : '' unless @board.nil? %>">
-    <%= link_to board.name, board_path(board), class: 'nav-link' %>
+<% if @boards.length > 5 %>
+  <li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Boards
+    </a>
+    <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+      <% boards.each do |board| %>
+        <li class="<%= board.id == @board&.id ? 'active' : '' %>">
+          <%= link_to board.name, board_path(board), class: 'nav-link' %>
+        </li>
+      <% end %>
+    </ul>
   </li>
+<% else %>
+  <% boards.each do |board| %>
+    <li class="nav-item<%= board.id == @board&.id ? ' active' : '' %>">
+      <%= link_to board.name, board_path(board), class: 'nav-link' %>
+    </li>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Hello, thanks for making this awesome project!

I've made a small UI patch. I noticed if I have a lot of feedback boards, the nav overflows and I need to scroll in the browser to see them all. I think this is a nice workaround.

With 1-5 boards:

<img width="1003" alt="Screen Shot 2021-07-23 at 5 16 05 PM" src="https://user-images.githubusercontent.com/49627084/126846716-a00aac83-c436-427c-b6da-510805045606.png">

With > 5 boards:

<img width="550" alt="Screen Shot 2021-07-23 at 5 14 36 PM" src="https://user-images.githubusercontent.com/49627084/126846720-02916c2a-7a03-431c-935d-48468258a100.png">
