### PR TITLE
Update .env-example

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -9,7 +9,7 @@ SECRET_KEY_BASE=secretkeybasehere
 POSTGRES_USER=yourusernamehere
 POSTGRES_PASSWORD=yourpasswordhere
 
-APP_NAME=You App Name Here
+APP_NAME="You App Name Here"
 SHOW_LOGO=yes
 POSTS_PER_PAGE=15
 


### PR DESCRIPTION
Update `.env-example`, fix  "key cannot contain a space" error.