### PR TITLE
Archive stale posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,10 @@ gem 'react-rails', '2.6.2'
 # Pagination
 gem 'kaminari', '1.2.2'
 
+# Asynchronous workers
+gem 'sidekiq'
+gem 'sidekiq-cron'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
     execjs (2.8.1)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
@@ -103,6 +105,9 @@ GEM
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
     ffi (1.15.5)
+    fugit (1.8.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.21.0)
@@ -168,6 +173,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.2.0)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.6.2)
     rack (2.2.7)
     rack-test (2.1.0)
@@ -208,6 +214,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redis (4.8.1)
     regexp_parser (2.5.0)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -235,6 +242,14 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
+    sidekiq (6.5.9)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
+    sidekiq-cron (1.10.1)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -296,6 +311,8 @@ DEPENDENCIES
   react-rails (= 2.6.2)
   rspec-rails (= 4.0.2)
   selenium-webdriver (= 4.1.0)
+  sidekiq
+  sidekiq-cron
   spring (= 2.1.1)
   spring-watcher-listen (= 2.0.1)
   turbolinks (= 5.2.1)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bin/rails server -b 0.0.0.0 -p 3000
 css: yarn build:css --watch --color
 js: yarn build --watch --color
+sidekiq: bundle exec sidekiq

--- a/app/controllers/post_settings_controller.rb
+++ b/app/controllers/post_settings_controller.rb
@@ -1,0 +1,89 @@
+class PostSettingsController < ApplicationController
+  before_action :authenticate_user!, only: [:index, :show, :create, :update, :destroy]
+
+  def index
+    post_settings = PostSetting.all
+
+    unless policy(post_settings).index?
+      raise Pundit::NotAuthorizedError
+    end
+
+    render json: post_settings
+  end
+
+  def create
+    @post_setting = PostSetting.new
+
+    unless policy(@post_setting).create?
+      raise Pundit::NotAuthorizedError
+    end
+
+    @post_setting.assign_attributes(post_setting_create_params)
+
+    if @post_setting.save
+      render json: @post_setting, status: :created
+    else
+      render json: {
+        error: @post_setting.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @post_setting = PostSetting.find(params[:id])
+
+    unless policy(@post_setting).show?
+      raise Pundit::NotAuthorizedError
+    end
+
+    respond_to do |format|
+      format.html
+
+      format.json { render json: @post_setting }
+    end
+  end
+
+  def update
+    @post_setting = PostSetting.find(params[:id])
+    authorize @post_setting
+
+    @post_setting.assign_attributes(post_setting_update_params)
+
+    if @post_setting.save
+      render json: @post_setting
+    else
+      render json: {
+        error: @post_setting.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @post_setting = PostSetting.find(params[:id])
+    authorize @post_setting
+
+    if @post_setting.destroy
+      render json: {
+        id: @post_setting.id,
+      }, status: :accepted
+    else
+      render json: {
+        error: @post_setting.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def post_setting_create_params
+      params
+        .require(:post_setting)
+        .permit(policy(@post_setting).permitted_attributes_for_create)
+    end
+
+    def post_setting_update_params
+      params
+        .require(:post_setting)
+        .permit(policy(@post_setting).permitted_attributes_for_update)
+    end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,6 +4,7 @@ class Post < ApplicationRecord
   belongs_to :board
   belongs_to :user
   belongs_to :post_status, optional: true
+  belongs_to :post_setting, optional: true
 
   has_many :likes, dependent: :destroy
   has_many :follows, dependent: :destroy

--- a/app/models/post_setting.rb
+++ b/app/models/post_setting.rb
@@ -1,0 +1,5 @@
+class PostSetting < ApplicationRecord
+  include TenantOwnable
+  
+  has_many :posts
+end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -5,7 +5,7 @@ class PostPolicy < ApplicationPolicy
 
   def permitted_attributes_for_update
     if user.moderator?
-      [:title, :description, :board_id, :post_status_id]
+      [:title, :description, :board_id, :post_status_id, :post_settings_id]
     else
       [:title, :description]
     end

--- a/app/policies/post_setting_policy.rb
+++ b/app/policies/post_setting_policy.rb
@@ -1,0 +1,29 @@
+class PostSettingPolicy < ApplicationPolicy
+  def permitted_attributes_for_create
+    [:archive_after]
+  end
+
+  def permitted_attributes_for_update
+    [:archive_after]
+  end
+
+  def index?
+    user.admin?
+  end
+
+  def show?
+    user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+  
+  def update?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+end

--- a/app/sidekiq/posts_archiver_executor_job.rb
+++ b/app/sidekiq/posts_archiver_executor_job.rb
@@ -1,0 +1,28 @@
+class PostsArchiverExecutorJob
+  include Sidekiq::Job
+
+  def perform(tenant_id, post_id, post_status_id)
+    Current.tenant = Tenant.find(tenant_id)
+
+    post = Post.find_by(id: post_id)
+    return if post.blank?
+
+    post_setting = PostSetting.find_by(id: post.post_settings_id)
+    return unless stale_post?(post, post_setting)
+
+    post_status = PostStatus.find_by(id: post_status_id)
+    if post_status.blank?
+      post_setting.update(archive_after: 0)
+      return
+    end
+
+    post.update(post_status_id: post_status_id)
+    UserMailer.notify_followers_of_post_status_change(post: post).deliver_later
+  end
+
+  private
+
+  def stale_post?(post, post_setting)
+    post.updated_at < DateTime.now - (post_setting.archive_after || 0).seconds
+  end
+end

--- a/app/sidekiq/posts_archiver_fanout_job.rb
+++ b/app/sidekiq/posts_archiver_fanout_job.rb
@@ -1,0 +1,36 @@
+class PostsArchiverFanoutJob
+  include Sidekiq::Job
+
+  def perform
+    with_stale_post_ids do |tenant_id, stale_post_ids, archived_status_id|
+      stale_post_ids.each do |stale_post_id|
+        PostsArchiverExecutorJob.perform_async(tenant_id, stale_post_id, archived_status_id)
+      end
+    end
+  end
+
+  private
+
+  def with_tenant
+    tenants = Tenant.all
+    tenants.each do |tenant|
+      Current.tenant = tenant
+      yield tenant
+    end
+  end
+
+  def with_stale_post_ids
+    with_tenant do |tenant|
+      archived_status = PostStatus.find_by(name: "Rejected")
+      return if archived_status.blank?
+
+      stale_posts_query = <<~STALE_POSTS.squish
+        SELECT posts.id
+        FROM posts INNER JOIN post_settings ON post_settings.id = posts.post_settings_id
+        WHERE (posts.updated_at < NOW() - (post_settings.archive_after||' seconds')::interval)
+        AND (posts.post_status_id IS NULL OR posts.post_status_id <> #{archived_status.id});
+      STALE_POSTS
+      yield tenant.id, ActiveRecord::Base.connection.execute(stale_posts_query).to_a.each.with_object("id").map(&:[]), archived_status.id
+    end
+  end
+end

--- a/config/initializers/application.rb
+++ b/config/initializers/application.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_job.queue_adapter = :sidekiq

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_client do |config|
+  config.redis = { url: "redis://redis:6379" }
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: "redis://redis:6379" }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,10 +47,13 @@ Rails.application.routes.draw do
       patch 'update_order', on: :collection
     end
   
+    resources :post_settings, only: [:index, :show, :create, :update, :destroy]
+  
     namespace :site_settings do
       get 'general'
       get 'boards'
       get 'post_statuses'
+      get 'post_settings'
       get 'roadmap'
       get 'users'
       get 'authentication'

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,3 @@
+PostsArchiverFanoutJob:
+  cron: "*/5 * * * *"
+  class: "PostsArchiverFanoutJob"

--- a/db/migrate/20230719214348_create_post_settings.rb
+++ b/db/migrate/20230719214348_create_post_settings.rb
@@ -1,0 +1,12 @@
+class CreatePostSettings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :post_settings do |t|
+      t.integer :archive_after, null: false, default: 0
+      t.references :tenant, foreign_key: true, null: false
+
+      t.timestamps
+    end
+
+    add_reference :posts, :post_settings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_11_095500) do
+ActiveRecord::Schema.define(version: 2023_07_19_214348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,14 @@ ActiveRecord::Schema.define(version: 2023_02_11_095500) do
     t.index ["tenant_id"], name: "index_o_auths_on_tenant_id"
   end
 
+  create_table "post_settings", force: :cascade do |t|
+    t.integer "archive_after", default: 0, null: false
+    t.bigint "tenant_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tenant_id"], name: "index_post_settings_on_tenant_id"
+  end
+
   create_table "post_status_changes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -118,7 +126,9 @@ ActiveRecord::Schema.define(version: 2023_02_11_095500) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "tenant_id", null: false
+    t.bigint "post_settings_id"
     t.index ["board_id"], name: "index_posts_on_board_id"
+    t.index ["post_settings_id"], name: "index_posts_on_post_settings_id"
     t.index ["post_status_id"], name: "index_posts_on_post_status_id"
     t.index ["tenant_id"], name: "index_posts_on_tenant_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
@@ -183,6 +193,7 @@ ActiveRecord::Schema.define(version: 2023_02_11_095500) do
   add_foreign_key "likes", "tenants"
   add_foreign_key "likes", "users"
   add_foreign_key "o_auths", "tenants"
+  add_foreign_key "post_settings", "tenants"
   add_foreign_key "post_status_changes", "post_statuses"
   add_foreign_key "post_status_changes", "posts"
   add_foreign_key "post_status_changes", "tenants"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '3.4'
 services:
+  redis:
+    image: redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+    command: redis-server
+    ports:
+      - 6379
   db:
     image: postgres:14.5
     environment:
@@ -20,7 +31,10 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_started
+      redis:
+        condition: service_healthy
     
 volumes:
   dbdata:

--- a/spec/factories/post_setting.rb
+++ b/spec/factories/post_setting.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :post_setting do
+    archive_after { 0 }
+  end
+end

--- a/spec/requests/post_settings_controller_spec.rb
+++ b/spec/requests/post_settings_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'post_settings controller', type: :request do
+  let!(:user) { FactoryBot.create(:admin) }
+
+  before(:each) do
+    user.confirm
+    sign_in user
+  end
+
+  describe '.index' do
+    let!(:post_setting) { FactoryBot.create(:post_setting) }
+
+    it 'returns post settings' do
+      get post_settings_path
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response.dig(0, "id")).to eq(post_setting.id)
+      expect(parsed_response.dig(0, "archive_after")).to eq(post_setting.archive_after)
+    end
+  end
+
+  describe '.create' do
+    let(:archive_after) { 42 }
+
+    it 'creates a new post setting' do
+      post(
+        post_settings_path,
+        params: {
+          post_setting: {
+            archive_after: archive_after
+          }
+        }
+      )
+
+      expect(response).to have_http_status(:success)
+      expect(ActiveRecord::Base.connection.execute("SELECT \"archive_after\" FROM \"post_settings\" LIMIT 1").to_a.dig(0, "archive_after")).to eq(archive_after)
+    end
+  end
+end

--- a/spec/sidekiq/posts_archiver_executor_job_spec.rb
+++ b/spec/sidekiq/posts_archiver_executor_job_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe PostsArchiverExecutorJob, type: :job do
+  describe "#perform" do
+    let(:post_setting) { FactoryBot.create(:post_setting, archive_after: 3600) }
+    let!(:post_status) { FactoryBot.create(:post_status, name: "Rejected") }
+    
+    context "when post is stale" do
+      let!(:post) { FactoryBot.create(:post, post_settings_id: post_setting.id, updated_at: DateTime.now - 2.years) }
+
+      context "when post status is present" do
+        it "archives post" do
+          expect { described_class.new.perform(Current.tenant.id, post.id, post_status.id) }.to change { post.reload.post_status_id }.to(post_status.id)
+        end
+      end
+
+      context "when post status is not present" do
+        let!(:post_status) { nil }
+
+        it "not archives post" do
+          expect { described_class.new.perform(Current.tenant.id, post.id, 0) }.to not_change { post.reload.post_status_id }
+        end
+      end
+    end
+
+    context "when post is not stale" do
+      let!(:post) { FactoryBot.create(:post, post_settings_id: post_setting.id, updated_at: DateTime.now - 2.seconds) }
+
+      it "not archives post" do
+        expect { described_class.new.perform(Current.tenant.id, post.id, post_status.id) }.to not_change { post.reload.post_status_id }
+      end
+    end
+  end
+end

--- a/spec/sidekiq/posts_archiver_fanout_job_spec.rb
+++ b/spec/sidekiq/posts_archiver_fanout_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe PostsArchiverFanoutJob, type: :job do
+  describe "#perform" do
+    let(:post_setting) { FactoryBot.create(:post_setting, archive_after: 3600) }
+    let!(:post_status) { FactoryBot.create(:post_status, name: "Rejected") }
+    let!(:stale_posts) { FactoryBot.create_list(:post, 2, post_settings_id: post_setting.id, updated_at: DateTime.now - 2.years) }
+    let!(:fresh_posts) { FactoryBot.create_list(:post, 2, post_settings_id: post_setting.id) }
+
+    it "enqueues jobs with stale posts only" do
+      expect(PostsArchiverExecutorJob).to receive(:perform_async) do |tenant_id, post_id, post_status_id|
+        expect(tenant_id).to eq(Current.tenant.id)
+        expect(post_id.in?(stale_posts.map(&:id))).to eq(true)
+        expect(post_status_id).to eq(post_status.id)
+      end.twice
+      described_class.new.perform
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.configure do |config|
   ENV["RAILS_ENV"] = "test"
 


### PR DESCRIPTION
### What, Why and How

Posts that are not updated for a long time become stale.

We want to archive stale posts by changing their status automatically, to avoid clutter and maintain focus on the core issues.

Introduces a new table `post_settings` to keep a setting of how long to wait before archiving stale posts. Introduces a worker and scheduler to asyncrhonously check every 5 minutes for stale posts and archive them.

### Examples

Currently post settings can be created and updated via Rails console or HTTP requests. There's no frontend for it yet.

```
curl -XPOST -H 'Cookie: COOKIE_GOES_HERE' -H 'X-Csrf-Token: CSRF_TOKEN_GOES_HERE' -H "Content-type: application/json" -d '{ "post_setting": { "archive_after": TIME_IN_SECONDS_TO_ARCHIVE_POST_AFTER_LAST_UPDATED } }' 'http://localhost:3000/post_settings'

curl -XPUT -H 'Cookie: COOKIE_GOES_HERE' -H 'X-Csrf-Token: CSRF_TOKEN_GOES_HERE' -H "Content-type: application/json" -d '{ "post": { "post_settings_id": ID_OF_NEWLY_CREATED_POST_SETTING } }' 'http://localhost:3000/posts/ID_OF_POST_TO_UPDATE'
```