### PR TITLE
Allow configuring database hostname

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
+  host: <%= ENV.fetch("POSTGRES_HOST", "db") %>
   username: <%= ENV['POSTGRES_USER'] %>
   password: <%= ENV['POSTGRES_PASSWORD'] %>
 


### PR DESCRIPTION
## Changes

The database hostname can now be configured using the env variable `POSTGRES_HOST` which matches the naming of the other postgres variable.

The default value for this variable is `db` which makes it backward compatible.

Fix #233 