### PR TITLE
Update webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :test do
   gem 'capybara', '3.36.0'
   gem 'selenium-webdriver', '4.1.0'
   # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers', '5.0.0'
+  gem 'webdrivers', '5.3.1'
 end
 
 # If not bundled, webpack compilation in production fails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,10 +261,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -301,7 +301,7 @@ DEPENDENCIES
   turbolinks (= 5.2.1)
   tzinfo-data
   web-console (>= 3.3.0)
-  webdrivers (= 5.0.0)
+  webdrivers (= 5.3.1)
 
 RUBY VERSION
    ruby 3.0.6p216


### PR DESCRIPTION
webdrivers 5.3.1 support latest google chrome out of the box

Fix #242 