### PR TITLE
Skip pipeline for site logo file/url

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
     <%=
       link_to root_path, class: 'brand' do
         app_name = content_tag :span, @tenant.site_name
-        logo = image_tag(@tenant.site_logo ? @tenant.site_logo : "", class: 'logo')
+        logo = image_tag(@tenant.site_logo ? @tenant.site_logo : "", class: 'logo', skip_pipeline: true)
 
         if @tenant_setting.brand_display == "name_and_logo"
           logo + app_name


### PR DESCRIPTION
Fixes #238
The ruby pipeline validation causes an exception if the file is missing, so pointing to an invalid file/url for the site logo makes every page crash

Skipping the pipeline will instead show a broken link icon
![image](https://github.com/astuto/astuto/assets/11025533/1f03199f-223e-41a0-b4e4-cfc46ef18965)
