### PR TITLE
Fix PostStatus deletion

### DIFF
--- a/app/models/post_status.rb
+++ b/app/models/post_status.rb
@@ -3,6 +3,7 @@ class PostStatus < ApplicationRecord
   include Orderable
 
   has_many :posts, dependent: :nullify
+  has_many :post_status_changes, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { scope: :tenant_id }
   validates :color, format: { with: /\A#(?:[0-9a-fA-F]{3}){1,2}\z/ }


### PR DESCRIPTION
Destroys dependent PostStatusChanges. Fixes #219 that prevented PostStatus entities to be deleted if there were some PostStatusChanges attached to it.