### PR TITLE
Remove version key, as it is deprecated.

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   web:
     build:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   web:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   db:
     image: postgres:14.5
@@ -21,6 +20,6 @@ services:
       - "3000:3000"
     depends_on:
       - db
-    
+
 volumes:
   dbdata:


### PR DESCRIPTION
- With the latest docker-compose versions, the `version` key has been deprecated and results in warnings. Removing the key fixes the warnings.
- Removing the key works with older versions of docker-compose too.
- Fixes #367 