### PR TITLE
Extract common env vars for enhanced readability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,15 @@
+#Extracted the default env outside for better readability
+#Ref Fragments: https://github.com/compose-spec/compose-spec/blob/master/spec.md#fragments
+#Ref Extension: https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
+x-env: &default-env
+  POSTGRES_USER: astuto
+  POSTGRES_PASSWORD: dbpass
+
 services:
   db:
     image: postgres:14.5
     environment:
-      POSTGRES_USER: astuto
-      POSTGRES_PASSWORD: dbpass
+      <<: *default-env
     volumes:
       - dbdata:/var/lib/postgresql/data
   web:
@@ -12,8 +18,7 @@ services:
       dockerfile: Dockerfile
       target: dev
     environment:
-      POSTGRES_USER: astuto
-      POSTGRES_PASSWORD: dbpass
+      <<: *default-env
       BASE_URL: http://localhost:3000
       SECRET_KEY_BASE: secretkeybasehere
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,9 @@
-#Extracted the default env outside for better readability
-#Ref Fragments: https://github.com/compose-spec/compose-spec/blob/master/spec.md#fragments
-#Ref Extension: https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
-x-env: &default-env
-  POSTGRES_USER: astuto
-  POSTGRES_PASSWORD: dbpass
-
 services:
   db:
     image: postgres:14.5
-    environment: *default-env
+    environment: &db-env
+      POSTGRES_USER: astuto
+      POSTGRES_PASSWORD: dbpass
     volumes:
       - dbdata:/var/lib/postgresql/data
   web:
@@ -17,7 +12,7 @@ services:
       dockerfile: Dockerfile
       target: dev
     environment:
-      <<: [*default-env]
+      <<: *db-env
       BASE_URL: http://localhost:3000
       SECRET_KEY_BASE: secretkeybasehere
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ x-env: &default-env
 services:
   db:
     image: postgres:14.5
-    environment:
-      <<: *default-env
+    environment: *default-env
     volumes:
       - dbdata:/var/lib/postgresql/data
   web:
@@ -18,7 +17,7 @@ services:
       dockerfile: Dockerfile
       target: dev
     environment:
-      <<: *default-env
+      <<: [*default-env]
       BASE_URL: http://localhost:3000
       SECRET_KEY_BASE: secretkeybasehere
     ports:


### PR DESCRIPTION
- Use fragments and extensions to extract common env vars
  thereby improving readability of the docker-compose file
  used for dev-setup.
- Fixes issue #167.